### PR TITLE
Add Google Analytics

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,16 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-129880281-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-129880281-1', { 'anonymize_ip': true });
+  </script>
+
 
   <link rel="shortcut icon" type="image/ico" href="{{ "/assets/images/favicon.png" | relative_url }}" />
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">


### PR DESCRIPTION
Since the press release is comming up, we want to know how many people are visiting the site.
We have set all privacy settings to max, so we should be fine.