### PR TITLE
English language site

### DIFF
--- a/_includes/english-site-structure.html
+++ b/_includes/english-site-structure.html
@@ -1,0 +1,10 @@
+<ul>
+  <li>
+    About Nuts
+    <ul>
+      <li>
+        <a class="page-link" href="{{ 'en/contact' | relative_url }}">Contact</a>
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/_includes/participants.html
+++ b/_includes/participants.html
@@ -1,10 +1,6 @@
-<div class="page-content">
-  <p>Dit initiatief wordt nu al ondersteund door deze partijen:</p>
-</div>
-
 <div class="participants">
   {% for participant in site.data.participants %}
-    <div class="participant" style="background-image: url('{{participant.image_url}}');">
+    <div class="participant" style="background-image: url('{{participant.image_url | relative_url }}');">
       <a href="{{participant.website_url}}" target="_blank"></a>
     </div>
   {% endfor %}

--- a/_layouts/english-default.html
+++ b/_layouts/english-default.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  {%- include head.html -%}
+
+  <body>
+
+    {%- if page.display_big_header -%}
+      <header id="site-header" class="site-header full-screen">
+        <div class="big_logo wrapper"></div>
+        <div class="bouncy-arrow" onclick="window.scrollTo({top: window.innerHeight, left: 0, behavior: 'smooth'})"></div>
+
+    {%- else -%}
+      <header class="site-header fixed {{page.header_image}}">
+    {%- endif -%}
+
+      <nav class="site-nav">
+        <div class="wrapper navigation">
+          <a href="{{ "/en" | relative_url }}" class="small_logo"></a>
+
+          <div class="right-menu">
+            <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+            <label for="nav-trigger">
+              <span class="menu-icon">
+                <svg viewBox="0 0 18 15" width="18px" height="15px">
+                  <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+                </svg>
+              </span>
+            </label>
+
+            <div class="nav-list">
+              {%- include english-site-structure.html -%}
+            </div>
+          </div>
+
+        </div>
+      </nav>
+    </header>
+
+    {{ content }}
+
+    <footer>
+      <div class="page-content">
+        <div class="wrapper">
+          <div class="left">
+            <h2>Join the initiative</h2>
+            <p>We're looking for more organisations and care professionals who wish to join our manifesto, support our values and help develop the healthcare infrastructure of the future.</p>
+            <a href="{{ 'en/contact' | relative_url }}" class="button">Contact us!</a>
+
+            <p>
+              <a class="follow-us-on-twitter">@stichtingNuts</a> (Dutch)<br/>
+              <a class="follow-us-on-twitter english">@nutsFoundation</a> (English, but not yet in use)
+            </p>
+          </div>
+
+          <div class="right">
+            <h2>Sitemap</h2>
+            {%- include english-site-structure.html -%}
+          </div>
+        </div>
+      </div>
+    </footer>
+
+  </body>
+</html>

--- a/_layouts/english-front-page.html
+++ b/_layouts/english-front-page.html
@@ -1,0 +1,23 @@
+---
+layout: english-default
+---
+
+<div class="page-content emphasis">
+  {{ content }}
+</div>
+
+<div class="page-block">
+  <div class="fancy-image contact"></div>
+</div>
+
+<div>
+  <div class="page-content">
+    <p>This initiative is already supported by these organisations:</p>
+  </div>
+
+  {%- include participants.html -%}
+</div>
+
+<div class="page-block">
+  <div class="fancy-image large powerlines"></div>
+</div>

--- a/_layouts/english-page.html
+++ b/_layouts/english-page.html
@@ -1,0 +1,7 @@
+---
+layout: english-default
+---
+
+<div class="page-content">
+  {{ content }}
+</div>

--- a/_layouts/front-page.html
+++ b/_layouts/front-page.html
@@ -28,6 +28,10 @@ layout: default
 </div>
 
 <div>
+  <div class="page-content">
+    <p>Dit initiatief wordt nu al ondersteund door deze partijen:</p>
+  </div>
+
   {%- include participants.html -%}
 </div>
 

--- a/assets/javascripts/social-media-buttons.js
+++ b/assets/javascripts/social-media-buttons.js
@@ -18,5 +18,6 @@ window.addEventListener('load', function() {
   bindSocialClick('.social-media-buttons .twitter',  'https://twitter.com/intent/tweet?url=' + pageUrl + '&text=' + encodeURIComponent('Wat een goed idee! #nuts'));
   bindSocialClick('.social-media-buttons .linkedin', 'https://www.linkedin.com/shareArticle?mini=true&url=' + pageUrl);
   bindSocialClick('.follow-us-on-twitter',           'https://twitter.com/intent/follow?screen_name=stichtingnuts');
+  bindSocialClick('.follow-us-on-twitter.english',   'https://twitter.com/intent/follow?screen_name=nutsfoundation');
 
 });

--- a/en/contact.md
+++ b/en/contact.md
@@ -1,0 +1,10 @@
+---
+layout: english-page
+title: Nuts
+permalink: /en/contact/
+---
+
+# Contact
+
+You can reach us at phone number [+31544471624](tel:+31544471624).<br/>
+Or send us an e-mail at [info@nuts.nl](mailto:info@nuts.nl).

--- a/en/index.md
+++ b/en/index.md
@@ -1,0 +1,34 @@
+---
+layout: english-front-page
+title: Nuts
+permalink: /en/
+display_big_header: true
+---
+
+# A decentralised infrastructure for healthcare
+
+Nuts is a fresh look at an old problem. Nuts is the realisation that the way
+medical data is currently being shared is pretty crazy.
+
+And Nuts is a collaboration of organisations that believe it is time for shared
+facilities ("Nutsvoorzieningen" in Dutch), a network built by anyone for
+everyone. The necessary infrastructure to communicate medical data in the
+primary care process.
+
+Because it really is possible to work together using computers instead of fax
+machines in healthcare. And it's possible to do so safely, securely and with no
+extra costs.
+
+## Care to know more?
+
+We are currently focussing on the Dutch healthcare market. So the English part
+of this website is pretty empty, and will be for the foreseeable future. You can
+try [browsing our Dutch website through Google translate](https://translate.google.com/translate?sl=nl&tl=en&u=nuts.nl)
+or you can [contact us]({{ 'contact' }}) if you would like to know more or join
+our cause!
+
+## For developers
+
+Our [Github](https://github.com/nuts-foundation) organisation and our
+[technical documentation](https://nuts-documentation.readthedocs.io/) are both
+in English!


### PR DESCRIPTION
Make a start at an English website at `www.nuts.nl/en`. Asked Robin to have `www.nuts.foundation` redirect there.

Mostly this version of the website is there as an empty placeholder to welcome English speaking visitors and redirect developers to the Github page and documentation site.