### PR TITLE
Add English jobs page

### DIFF
--- a/_includes/english-site-structure.html
+++ b/_includes/english-site-structure.html
@@ -9,10 +9,10 @@
         <a class="page-link" href="{{ 'en/privacy-policy' | relative_url }}">Privacy policy</a>
       </li>
       <li>
-        <a class="page-link" href="{{ 'en/contact' | relative_url }}">Contact</a>
+        <a class="page-link" href="{{ 'en/jobs' | relative_url }}">Jobs</a>
       </li>
       <li>
-        <a class="page-link" href="{{ 'en/jobs' | relative_url }}">Jobs</a>
+        <a class="page-link" href="{{ 'en/contact' | relative_url }}">Contact</a>
       </li>
     </ul>
   </li>

--- a/_includes/english-site-structure.html
+++ b/_includes/english-site-structure.html
@@ -11,6 +11,9 @@
       <li>
         <a class="page-link" href="{{ 'en/contact' | relative_url }}">Contact</a>
       </li>
+      <li>
+        <a class="page-link" href="{{ 'en/jobs' | relative_url }}">Jobs</a>
+      </li>
     </ul>
   </li>
 </ul>

--- a/_includes/site-structure.html
+++ b/_includes/site-structure.html
@@ -52,6 +52,9 @@
         <a class="page-link" href="{{ 'privacy-policy' | relative_url }}">Privacy policy</a>
       </li>
       <li>
+        <a class="page-link" href="{{ '/en/jobs' | relative_url }}">Jobs</a>
+      </li>
+      <li>
         <a class="page-link" href="{{ 'contact' | relative_url }}">Contact</a>
       </li>
     </ul>

--- a/en/jobs.md
+++ b/en/jobs.md
@@ -7,37 +7,20 @@ header_image: components
 
 # Jobs
 
-This is an overview of the Nuts-related jobs that we know are available in the
-healthcare IT market.
+This is an overview of the Nuts-related jobs that we know are available in the Nuts Community.
 
-## Go Developer at Nedap Healthcare
+## Go Developer at _Nedap Healthcare_
 
-We’re looking for an experienced Go developer to join our development team. This
-assignment is for a duration of 1 year and can be extended depending on the
-renewal of external funding.
-
+We’re looking for an experienced Go developer to join our development team. This assignment is for a duration of 1 year and can be extended depending on the renewal of external funding. 
 ### About Nuts
 
-Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We
-build open standards and software to standardize the tedious work of creating
-safe connections between electronic health records systems, required to exchange
-medical information. Every EHR system spins up a local Nuts-node which becomes
-part of a large and decentralized trust network. Your job will be developing
-these standards and implementing them in the Nuts-node software.
+Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We build open standards and software to standardize the tedious work of creating safe connections between electronic health records systems, required to exchange medical information. Every EHR system spins up a local Nuts-node which becomes part of a large and decentralized trust network. Your job will be developing these standards and implementing them in the Nuts-node software.
 
 ### What we expect of you
 
-You’ll be working on open-source software, so you are the type of person that
-likes to share your work with the world. You like working with decentralized
-identity frameworks, blockchain-like solutions, peer-2-peer technology and
-various cryptographic schemes. We’re not just trying to build a healthcare
-infrastructure, we’re building an infrastructure that is fair, future-proof and
-scalable! Do you want to work on next-gen technology and do something good for
-the world at the same time?
+You’ll be working on open-source software, so you are the type of person that likes to share your work with the world. You like working with decentralized identity frameworks, blockchain-like solutions, peer-2-peer technology and various cryptographic schemes. We’re not just trying to build a healthcare infrastructure, we’re building an infrastructure that is fair, future-proof and scalable! Do you want to work on next-gen technology and do something good for the world at the same time?
 
-We would like you to hit the ground running. This means you have a lot of
-experience with the Go programming language in addition to the following
-subjects:
+We would like you to hit the ground running. This means you have a lot of experience with the Go programming language in addition to the following subjects:
 
 * Several cryptographic schemes
 * Writing and testing high quality software
@@ -48,29 +31,15 @@ subjects:
 
 ### Your employer
 
-Since Nuts is a decentralized initiative, the actual position is offered by one
-of the participating organisations. For this specific position, the offering
-organisation is [Nedap Healthcare](https://nedap.com/): A Dutch company located
-in Groenlo, the Netherlands.
+Since Nuts is a decentralized initiative, the actual position is offered by one of the participating organisations. For this specific position, the offering organisation is [Nedap Healthcare](https://nedap.com/): A Dutch company located in Groenlo, the Netherlands.
 
 ### Your team
 
-You'll be joining an open-source community. The majority of the interaction will
-be with the "core-team". This is a team of several enthusiastic and highly
-skilled people, each with their own interests. Every member is treated equally
-and a well-motivated opinion is highly appreciated. Most of the interaction will
-be online through Slack and Zoom. Most core-members live in the eastern part of
-the Netherlands and therefore have the ability to meet face-to-face but the team
-is also perfectly fine with joining you remotely. In order for the team to
-communicate optimally, it's required you're able to meet face to face
-(webcam-wise) on a daily basis. We encourage you to make your own schedule but
-keep in mind the core-team is located in the CET time zone.
+You'll be joining an open-source community. The majority of the interaction will be with the "core-team". This is a team of several enthusiastic and highly skilled people, each with their own interests. Every member is treated equally and a well-motivated opinion is highly appreciated. Most of the interaction will be online through Slack and Zoom. Most core-members live in the eastern part of the Netherlands and therefore have the ability to meet face-to-face but the team is also perfectly fine with joining you remotely. In order for the team to communicate optimally, it's required you're able to meet face to face (webcam-wise) on a daily basis. We encourage you to make your own schedule but keep in mind the core-team is located in the CET time zone.
 
 ### Our offer
 
-A challenging role with a dynamic and international company. A job with a lot of
-responsibility, but also the freedom to organize it in such a way that you can
-really make a difference!
+A challenging role with a dynamic and international company. A job with a lot of responsibility, but also the freedom to organize it in such a way that you can really make a difference!
 
 ### Check out our codebase!
 
@@ -80,6 +49,4 @@ Our [Github Repository](https://github.com/nuts-foundation) the
 
 ### How to apply
 
-If you are interested in this position, contact us via jobs@nuts.nl or use the
-form on the [Nedap Healthcare
-Jobs](https://nedap.com/vacancy/go-developer-temporary/) website.
+If you are interested in this position, contact us via jobs@nuts.nl or use the form on the [Nedap Healthcare Jobs](https://nedap.com/vacancy/go-developer-temporary/) website.

--- a/en/jobs.md
+++ b/en/jobs.md
@@ -9,7 +9,7 @@ display_big_header: false
 
 # Go Developer
 
-We’re looking for an experienced Go developer to join our development team. This assignment is for a duration of 1 year.
+We’re looking for an experienced Go developer to join our development team. This assignment is for a duration of 1 year and can be extended depending on the renewal of external funding.
 
 ## About Nuts
 Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We build open standards and software to standardize the tedious work of creating safe connections between electronic health records systems, required to exchange medical information. Every EHR system spins up a local Nuts-node which becomes part of a large and decentralized trust network. Your job will be developing these standards and implementing them in the Nuts-node software.
@@ -17,21 +17,20 @@ Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We bu
 ## What we expect of you
 You’ll be working on open-source software, so you are the type of person that likes to share your work with the world. You like working with decentralized identity frameworks, blockchain-like solutions, peer-2-peer technology and various cryptographic schemes. We’re not just trying to build a healthcare infrastructure, we’re building an infrastructure that is fair, future-proof and scalable! Do you want to work on next-gen technology and do something good for the world at the same time?
 
-Since it’s an assignment for a limited time, you’ll need to hit the ground running. This means you have a lot of experience with the Go programming language and you’re able to build systems from the ground up.
+We would like you to hit the ground running. This means you have a lot of experience with the Go programming language in addition to the following subjects:
 
-To sum it up, you have extensive experience with the following:
-* The Go programming language
 * Several cryptographic schemes
+* Writing and testing high quality software
 * Writing API specifications using OpenAPI Specification (Swagger doc)
 * Writing reusable software specifications (RFCs)
-* Distributed systems in general
+* Distributed systems and networking in general
 * Docker and basic DevOps
 
 ## Your employer
-Since Nuts is a decentralized initiative, the actual position is offered by one of the participating organizations. For this specific position, the offering organization is [Nedap Healthcare](https://nedap.com/): A Dutch company located in Groenlo, the Netherlands.
+Since Nuts is a decentralized initiative, the actual position is offered by one of the participating organisations. For this specific position, the offering organisation is [Nedap Healthcare](https://nedap.com/): A Dutch company located in Groenlo, the Netherlands.
 
 ## Your team
-You'll be joining an open-source community. The majority of the interaction will be with the "core-team". This is a team of several enthusiastic and highly skilled people, each with their own interests. Every member is treated equally and a well-motivated opinion is highly appreciated. Most of the interaction will be online through Slack and Zoom. Most core-members live in the eastern part of the Netherlands and therefore have the ability to meet face-to-face but the team is also perfectly fine with joining you remotely. In order for the team to communicate optimally, it's required you're being able to meet face to face on a daily basis. We encourage you to make your own schedule but keep in mind the core-team is located in the CET time zone.
+You'll be joining an open-source community. The majority of the interaction will be with the "core-team". This is a team of several enthusiastic and highly skilled people, each with their own interests. Every member is treated equally and a well-motivated opinion is highly appreciated. Most of the interaction will be online through Slack and Zoom. Most core-members live in the eastern part of the Netherlands and therefore have the ability to meet face-to-face but the team is also perfectly fine with joining you remotely. In order for the team to communicate optimally, it's required you're able to meet face to face (webcam-wise) on a daily basis. We encourage you to make your own schedule but keep in mind the core-team is located in the CET time zone.
 
 ## Our offer
 A challenging role with a dynamic and international company. A job with a lot of responsibility, but also the freedom to organize it in such a way that you can really make a difference!
@@ -43,4 +42,4 @@ Our [Github Repository](https://github.com/nuts-foundation) the
 [Software Documentation](https://nuts-node.readthedocs.io/en/latest/).
 
 ## How to apply
-If you are interested in this position, contact us via jobs@nuts.nl or use the form the [Nedap Healthcare Jobs](https://nedap.com/vacancy/go-developer-temporary/) website.
+If you are interested in this position, contact us via jobs@nuts.nl or use the form on the [Nedap Healthcare Jobs](https://nedap.com/vacancy/go-developer-temporary/) website.

--- a/en/jobs.md
+++ b/en/jobs.md
@@ -9,13 +9,13 @@ display_big_header: false
 
 # Go Developer
 
-We’re looking for an experienced Go developer to join our development team until the end of this year (this is an assignment for a limited time, since it’s subsidized by a national program).
+We’re looking for an experienced Go developer to join our development team. This assignment is for a duration of 1 year.
 
 ## About Nuts
-Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We build open standards and a reference implementation to solve the tedious work of creating save connections between electronic health records systems to exchange medical information. Every EHR system spins up a local Nuts-node which becomes part of a large trust network. Your job will be developing these standards and implementing them in the Nuts-node software.
+Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We build open standards and a reference implementation to solve the tedious work of creating safe connections between electronic health records systems to exchange medical information. Every EHR system spins up a local Nuts-node which becomes part of a large trust network. Your job will be developing these standards and implementing them in the Nuts-node software.
 
 ## What we expect of you
-You’ll be working on open source software, so you are the type of person that likes to share your work with the world. You like working with decentralized identity frameworks, blockchain-like solutions, peer-2-peer technology and various cryptographic schemes. We’re not just trying to build a healthcare infrastructure, we’re building an infrastructure that is fair, future-proof and scalable! Do you want to work on next-gen technology and do something good for the world at the same time?
+You’ll be working on open-source software, so you are the type of person that likes to share your work with the world. You like working with decentralized identity frameworks, blockchain-like solutions, peer-2-peer technology and various cryptographic schemes. We’re not just trying to build a healthcare infrastructure, we’re building an infrastructure that is fair, future-proof and scalable! Do you want to work on next-gen technology and do something good for the world at the same time?
 
 Since it’s an assignment for limited time, you’ll need to hit the ground running. This means you have a lot of experience with the Go programming language and you’re able to build systems from the ground up.
 

--- a/en/jobs.md
+++ b/en/jobs.md
@@ -7,7 +7,10 @@ header_image: components
 
 # Jobs
 
-## Go Developer
+This is an overview of the Nuts-related jobs that we know are available in the
+healthcare IT market.
+
+## Go Developer at Nedap Healthcare
 
 We’re looking for an experienced Go developer to join our development team. This
 assignment is for a duration of 1 year and can be extended depending on the

--- a/en/jobs.md
+++ b/en/jobs.md
@@ -2,7 +2,7 @@
 layout: english-page
 title: Jobs
 permalink: /en/jobs
-header_image: components
+header_image: manifest
 ---
 
 # Jobs

--- a/en/jobs.md
+++ b/en/jobs.md
@@ -12,7 +12,7 @@ display_big_header: false
 We’re looking for an experienced Go developer to join our development team. This assignment is for a duration of 1 year.
 
 ## About Nuts
-Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We build open standards and a reference implementation to solve the tedious work of creating safe connections between electronic health records systems to exchange medical information. Every EHR system spins up a local Nuts-node which becomes part of a large trust network. Your job will be developing these standards and implementing them in the Nuts-node software.
+Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We build open standards and software to standardize the tedious work of creating safe connections between electronic health records systems, required to exchange medical information. Every EHR system spins up a local Nuts-node which becomes part of a large and decentralized trust network. Your job will be developing these standards and implementing them in the Nuts-node software.
 
 ## What we expect of you
 You’ll be working on open-source software, so you are the type of person that likes to share your work with the world. You like working with decentralized identity frameworks, blockchain-like solutions, peer-2-peer technology and various cryptographic schemes. We’re not just trying to build a healthcare infrastructure, we’re building an infrastructure that is fair, future-proof and scalable! Do you want to work on next-gen technology and do something good for the world at the same time?
@@ -21,11 +21,11 @@ Since it’s an assignment for limited time, you’ll need to hit the ground run
 
 To sum it up, you have extensive experience with the following:
 * The Go programming language
-* Basic cryptographic schemes
-* Writing API specification using OpenAPI Specification (Swagger doc)
-* Writing reusable specifications
+* Several cryptographic schemes
+* Writing API specifications using OpenAPI Specification (Swagger doc)
+* Writing reusable software specifications (RFCs)
 * Distributed systems in general
-* Docker
+* Docker and basic DevOps
 
 ## Your employer
 Since Nuts is a decentralized initiative, the actual position is offered by one of the participating organisations. For this specific position, the offering organisation is [Nedap Healthcare](https://nedap.com/): A Dutch company located in Groenlo, the Netherlands.

--- a/en/jobs.md
+++ b/en/jobs.md
@@ -1,23 +1,40 @@
 ---
-layout: english-front-page
+layout: english-page
 title: Jobs
 permalink: /en/jobs
-display_big_header: false
+header_image: components
 ---
 
 # Jobs
 
-# Go Developer
+## Go Developer
 
-We’re looking for an experienced Go developer to join our development team. This assignment is for a duration of 1 year and can be extended depending on the renewal of external funding.
+We’re looking for an experienced Go developer to join our development team. This
+assignment is for a duration of 1 year and can be extended depending on the
+renewal of external funding.
 
-## About Nuts
-Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We build open standards and software to standardize the tedious work of creating safe connections between electronic health records systems, required to exchange medical information. Every EHR system spins up a local Nuts-node which becomes part of a large and decentralized trust network. Your job will be developing these standards and implementing them in the Nuts-node software.
+### About Nuts
 
-## What we expect of you
-You’ll be working on open-source software, so you are the type of person that likes to share your work with the world. You like working with decentralized identity frameworks, blockchain-like solutions, peer-2-peer technology and various cryptographic schemes. We’re not just trying to build a healthcare infrastructure, we’re building an infrastructure that is fair, future-proof and scalable! Do you want to work on next-gen technology and do something good for the world at the same time?
+Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We
+build open standards and software to standardize the tedious work of creating
+safe connections between electronic health records systems, required to exchange
+medical information. Every EHR system spins up a local Nuts-node which becomes
+part of a large and decentralized trust network. Your job will be developing
+these standards and implementing them in the Nuts-node software.
 
-We would like you to hit the ground running. This means you have a lot of experience with the Go programming language in addition to the following subjects:
+### What we expect of you
+
+You’ll be working on open-source software, so you are the type of person that
+likes to share your work with the world. You like working with decentralized
+identity frameworks, blockchain-like solutions, peer-2-peer technology and
+various cryptographic schemes. We’re not just trying to build a healthcare
+infrastructure, we’re building an infrastructure that is fair, future-proof and
+scalable! Do you want to work on next-gen technology and do something good for
+the world at the same time?
+
+We would like you to hit the ground running. This means you have a lot of
+experience with the Go programming language in addition to the following
+subjects:
 
 * Several cryptographic schemes
 * Writing and testing high quality software
@@ -26,20 +43,40 @@ We would like you to hit the ground running. This means you have a lot of experi
 * Distributed systems and networking in general
 * Docker and basic DevOps
 
-## Your employer
-Since Nuts is a decentralized initiative, the actual position is offered by one of the participating organisations. For this specific position, the offering organisation is [Nedap Healthcare](https://nedap.com/): A Dutch company located in Groenlo, the Netherlands.
+### Your employer
 
-## Your team
-You'll be joining an open-source community. The majority of the interaction will be with the "core-team". This is a team of several enthusiastic and highly skilled people, each with their own interests. Every member is treated equally and a well-motivated opinion is highly appreciated. Most of the interaction will be online through Slack and Zoom. Most core-members live in the eastern part of the Netherlands and therefore have the ability to meet face-to-face but the team is also perfectly fine with joining you remotely. In order for the team to communicate optimally, it's required you're able to meet face to face (webcam-wise) on a daily basis. We encourage you to make your own schedule but keep in mind the core-team is located in the CET time zone.
+Since Nuts is a decentralized initiative, the actual position is offered by one
+of the participating organisations. For this specific position, the offering
+organisation is [Nedap Healthcare](https://nedap.com/): A Dutch company located
+in Groenlo, the Netherlands.
 
-## Our offer
-A challenging role with a dynamic and international company. A job with a lot of responsibility, but also the freedom to organize it in such a way that you can really make a difference!
+### Your team
 
-## Check out our codebase!
+You'll be joining an open-source community. The majority of the interaction will
+be with the "core-team". This is a team of several enthusiastic and highly
+skilled people, each with their own interests. Every member is treated equally
+and a well-motivated opinion is highly appreciated. Most of the interaction will
+be online through Slack and Zoom. Most core-members live in the eastern part of
+the Netherlands and therefore have the ability to meet face-to-face but the team
+is also perfectly fine with joining you remotely. In order for the team to
+communicate optimally, it's required you're able to meet face to face
+(webcam-wise) on a daily basis. We encourage you to make your own schedule but
+keep in mind the core-team is located in the CET time zone.
 
-Our [Github Repository](https://github.com/nuts-foundation) the 
+### Our offer
+
+A challenging role with a dynamic and international company. A job with a lot of
+responsibility, but also the freedom to organize it in such a way that you can
+really make a difference!
+
+### Check out our codebase!
+
+Our [Github Repository](https://github.com/nuts-foundation) the
 [Nuts Specifications](https://nuts-foundation.gitbook.io/drafts/) and
 [Software Documentation](https://nuts-node.readthedocs.io/en/latest/).
 
-## How to apply
-If you are interested in this position, contact us via jobs@nuts.nl or use the form on the [Nedap Healthcare Jobs](https://nedap.com/vacancy/go-developer-temporary/) website.
+### How to apply
+
+If you are interested in this position, contact us via jobs@nuts.nl or use the
+form on the [Nedap Healthcare
+Jobs](https://nedap.com/vacancy/go-developer-temporary/) website.

--- a/en/jobs.md
+++ b/en/jobs.md
@@ -17,7 +17,7 @@ Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We bu
 ## What we expect of you
 You’ll be working on open-source software, so you are the type of person that likes to share your work with the world. You like working with decentralized identity frameworks, blockchain-like solutions, peer-2-peer technology and various cryptographic schemes. We’re not just trying to build a healthcare infrastructure, we’re building an infrastructure that is fair, future-proof and scalable! Do you want to work on next-gen technology and do something good for the world at the same time?
 
-Since it’s an assignment for limited time, you’ll need to hit the ground running. This means you have a lot of experience with the Go programming language and you’re able to build systems from the ground up.
+Since it’s an assignment for a limited time, you’ll need to hit the ground running. This means you have a lot of experience with the Go programming language and you’re able to build systems from the ground up.
 
 To sum it up, you have extensive experience with the following:
 * The Go programming language
@@ -28,18 +28,19 @@ To sum it up, you have extensive experience with the following:
 * Docker and basic DevOps
 
 ## Your employer
-Since Nuts is a decentralized initiative, the actual position is offered by one of the participating organisations. For this specific position, the offering organisation is [Nedap Healthcare](https://nedap.com/): A Dutch company located in Groenlo, the Netherlands.
+Since Nuts is a decentralized initiative, the actual position is offered by one of the participating organizations. For this specific position, the offering organization is [Nedap Healthcare](https://nedap.com/): A Dutch company located in Groenlo, the Netherlands.
 
 ## Your team
-You'll be joining an open-source community. The majority of the interaction will be with the "core-team". This is a team of several enthusiastic and highly skilled people, each with their own interests. Every member is treated equally and a well-motivated opinion is highly appreciated. Most of the interaction will be online through Slack and Zoom. Most core-members live in the eastern part of the Netherlands and therefore have the ability to meet face-to-face but the team is also perfectly fine with joining you remotely. In order for the team to communicate optimally, it's required to live within +/- 3 hours of Central European Time.
+You'll be joining an open-source community. The majority of the interaction will be with the "core-team". This is a team of several enthusiastic and highly skilled people, each with their own interests. Every member is treated equally and a well-motivated opinion is highly appreciated. Most of the interaction will be online through Slack and Zoom. Most core-members live in the eastern part of the Netherlands and therefore have the ability to meet face-to-face but the team is also perfectly fine with joining you remotely. In order for the team to communicate optimally, it's required you're being able to meet face to face on a daily basis. We encourage you to make your own schedule but keep in mind the core-team is located in the CET time zone.
 
 ## Our offer
 A challenging role with a dynamic and international company. A job with a lot of responsibility, but also the freedom to organize it in such a way that you can really make a difference!
 
 ## Check out our codebase!
 
-Our [Github](https://github.com/nuts-foundation) and
-[technical documentation](https://nuts-documentation.readthedocs.io/).
+Our [Github Repository](https://github.com/nuts-foundation) the 
+[Nuts Specifications](https://nuts-foundation.gitbook.io/drafts/) and
+[Software Documentation](https://nuts-node.readthedocs.io/en/latest/).
 
 ## How to apply
-If you are interested in this position, contact Yorick Hoftijzer via the [Vacancy](https://nedap.com/vacancy/go-developer-temporary/) at the Nedap Healthcare website.
+If you are interested in this position, contact us via jobs@nuts.nl or use the form the [Nedap Healthcare Jobs](https://nedap.com/vacancy/go-developer-temporary/) website.

--- a/en/jobs.md
+++ b/en/jobs.md
@@ -1,0 +1,45 @@
+---
+layout: english-front-page
+title: Jobs
+permalink: /en/jobs
+display_big_header: false
+---
+
+# Jobs
+
+# Go Developer
+
+We’re looking for an experienced Go developer to join our development team until the end of this year (this is an assignment for a limited time, since it’s subsidized by a national program).
+
+## About Nuts
+Nuts is an initiative by around 30 parties in the Dutch healthcare domain. We build open standards and a reference implementation to solve the tedious work of creating save connections between electronic health records systems to exchange medical information. Every EHR system spins up a local Nuts-node which becomes part of a large trust network. Your job will be developing these standards and implementing them in the Nuts-node software.
+
+## What we expect of you
+You’ll be working on open source software, so you are the type of person that likes to share your work with the world. You like working with decentralized identity frameworks, blockchain-like solutions, peer-2-peer technology and various cryptographic schemes. We’re not just trying to build a healthcare infrastructure, we’re building an infrastructure that is fair, future-proof and scalable! Do you want to work on next-gen technology and do something good for the world at the same time?
+
+Since it’s an assignment for limited time, you’ll need to hit the ground running. This means you have a lot of experience with the Go programming language and you’re able to build systems from the ground up.
+
+To sum it up, you have extensive experience with the following:
+* The Go programming language
+* Basic cryptographic schemes
+* Writing API specification using OpenAPI Specification (Swagger doc)
+* Writing reusable specifications
+* Distributed systems in general
+* Docker
+
+## Your employer
+Since Nuts is a decentralized initiative, the actual position is offered by one of the participating organisations. For this specific position, the offering organisation is [Nedap Healthcare](https://nedap.com/): A Dutch company located in Groenlo, the Netherlands.
+
+## Your team
+You'll be joining an open-source community. The majority of the interaction will be with the "core-team". This is a team of several enthusiastic and highly skilled people, each with their own interests. Every member is treated equally and a well-motivated opinion is highly appreciated. Most of the interaction will be online through Slack and Zoom. Most core-members live in the eastern part of the Netherlands and therefore have the ability to meet face-to-face but the team is also perfectly fine with joining you remotely. In order for the team to communicate optimally, it's required to live within +/- 3 hours of Central European Time.
+
+## Our offer
+A challenging role with a dynamic and international company. A job with a lot of responsibility, but also the freedom to organize it in such a way that you can really make a difference!
+
+## Check out our codebase!
+
+Our [Github](https://github.com/nuts-foundation) and
+[technical documentation](https://nuts-documentation.readthedocs.io/).
+
+## How to apply
+If you are interested in this position, contact Yorick Hoftijzer via the [Vacancy](https://nedap.com/vacancy/go-developer-temporary/) at the Nedap Healthcare website.


### PR DESCRIPTION
For the Go developer vacancy I added this English page which we can link to from the goweekly mailinglist and possible other listings.