### PR TITLE
fix: trailing slashes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,7 @@ const nextConfig = {
     }
   },
   reactStrictMode: true,
+  trailingSlash: true,
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Disclaimer: Not sure if this works the way we want to.

Ref: https://nextjs.org/docs/pages/api-reference/next-config-js/exportPathMap#adding-a-trailing-slash