### PR TITLE
Update participants.json

### DIFF
--- a/config/participants.json
+++ b/config/participants.json
@@ -160,11 +160,6 @@
     "url": "https://tribeagency.nl/"
   },
   {
-    "title": "Vital Health Software",
-    "logoUrl": "/logos/vhs.png",
-    "url": "http://www.vitalhealthsoftware.nl/"
-  },
-  {
     "title": "Wijtz",
     "logoUrl": "/logos/wijtz.png",
     "url": "https://www.wijtz.nu/"


### PR DESCRIPTION
Vital Health verwijderd omdat deze geen partij is. Ook het logo zelf als bestand verwijderd.