### PR TITLE
Add 'careers' pages, fix 'use-cases'

### DIFF
--- a/content/posts/careers/system-architect.md
+++ b/content/posts/careers/system-architect.md
@@ -1,8 +1,7 @@
-
 ---
 layout: page
 title: System architect
-permalink: /system-architect.md
+permalink: /careers/system-architect/
 header_image: community
 ---
 

--- a/content/posts/careers/werken-bij.md
+++ b/content/posts/careers/werken-bij.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Werken-bij
-permalink: /werken-bij/
+permalink: /careers/werken-bij/
 header_image: community
 ---
 

--- a/content/posts/use-case/zorginzage.md
+++ b/content/posts/use-case/zorginzage.md
@@ -1,4 +1,5 @@
 ---
+permalink: /use-case/zorinzage
 title: zorginzage
 ---
 

--- a/content/posts/use-case/zorginzage.md
+++ b/content/posts/use-case/zorginzage.md
@@ -1,5 +1,5 @@
 ---
-permalink: /use-case/zorinzage
+permalink: /use-case/zorinzage/
 title: zorginzage
 ---
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -48,13 +48,14 @@ function getDirname(opts?: Opts): string {
 }
 
 export async function getPost(name: string, opts?: Opts): Promise<Post> {
-  if (!/^[a-zA-Z0-9-_\/]+$/.test(name)) {
+  if (!/^[a-zA-Z0-9-_]+$/.test(name)) {
     throw new Error(`invalid post name: ${name}`);
   }
 
   const source = await readFile(`${getDirname(opts)}/${name}.md`, "utf8");
   const { data, content } = matter(source);
   const output = await render(content);
+
   return new Post(name, data, output);
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -48,14 +48,13 @@ function getDirname(opts?: Opts): string {
 }
 
 export async function getPost(name: string, opts?: Opts): Promise<Post> {
-  if (!/^[a-zA-Z0-9-_]+$/.test(name)) {
+  if (!/^[a-zA-Z0-9-_\/]+$/.test(name)) {
     throw new Error(`invalid post name: ${name}`);
   }
 
   const source = await readFile(`${getDirname(opts)}/${name}.md`, "utf8");
   const { data, content } = matter(source);
   const output = await render(content);
-
   return new Post(name, data, output);
 }
 

--- a/pages/careers/[slug].tsx
+++ b/pages/careers/[slug].tsx
@@ -7,7 +7,7 @@ import { getPost, getPosts } from "../../lib/api"
 interface PostProps extends InferGetStaticPropsType<typeof getStaticProps> {
 }
 
-export default function UseCase({ post }: PostProps) {
+export default function Careers({ post }: PostProps) {
   return (
     <Layout>
       <NextSeo openGraph={{ title: `Nuts - ${post.meta["title"]}` }} />
@@ -25,7 +25,7 @@ export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
     throw new Error("invalid param");
   }
 
-  const post = await getPost(params["slug"] as string, { dir: "use-case" });
+  const post = await getPost(params["slug"] as string, { dir: "careers" });
 
   return {
     props: {
@@ -39,7 +39,7 @@ export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ }: GetStaticPathsContext) => {
-  const posts = await getPosts({ dir: "use-case" });
+  const posts = await getPosts({ dir: "careers" });
 
   return {
     fallback: "blocking",


### PR DESCRIPTION
Fixed "use-cases" directory/"slug" (lack of better name due to being a total nextjs noob). Or actually, GH Copilot did it for me.

Added "careers" (copy/paste from use-cases).