### PR TITLE
Update deprecated upload-pages-artifact action

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -81,7 +81,7 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
-        # Skip artifact on pull requests, only on merge (lets safe some bytes)
+        # Skip artifact on pull requests, only on merge (lets save some bytes)
         if: ${{ github.event_name != 'pull_request' }}
         with:
           path: ./out

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,6 +1,6 @@
 # To get started with Next.js see: https://nextjs.org/docs/getting-started
 #
-name: Deploy Next.js site to Pages
+name: Build
 
 on:
   # Runs on pushes targeting the default branch
@@ -81,6 +81,8 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        # Skip artifact on pull requests, only on merge (lets safe some bytes)
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           path: ./out
 
@@ -90,7 +92,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    # Skip deployment on pull requests, only on merge to main
+    # Skip deployment on pull requests, only on merge
     if: ${{ github.event_name != 'pull_request' }}
     needs: build
     steps:

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Static HTML export with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
 

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -6,6 +6,10 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
+  # Runs on pull requests to the default branch
+  pull_request:
+    branches:
+      - master
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -86,6 +90,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    # Skip deployment on pull requests, only on merge to main
+    if: ${{ github.event_name != 'pull_request' }}
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Build fails due to deprecated dependency upload-artifact

Also enables the build on all PRs, only actually deploy on merge.