### PR TITLE
Add LinkedIn feed on news page

### DIFF
--- a/components/LinkedInStream.tsx
+++ b/components/LinkedInStream.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+
+export default function LinkedInStream() {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://platform.linkedin.com/badges/js/profile.js";
+    script.async = true;
+    script.defer = true;
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div className="fixed top-24 right-4 w-80">
+      <div
+        className="LI-profile-badge"
+        data-version="v1"
+        data-size="medium"
+        data-locale="nl_NL"
+        data-type="company"
+        data-theme="light"
+        data-vanity="nuts-foundation"
+      >
+        <a
+          className="LI-simple-link"
+          href="https://nl.linkedin.com/company/nuts-foundation"
+        >
+          Nuts Foundation
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/pages/[name].tsx
+++ b/pages/[name].tsx
@@ -2,6 +2,7 @@ import { NextSeo } from "next-seo"
 import { GetStaticPaths, GetStaticPathsContext, GetStaticPropsContext, InferGetStaticPropsType } from "next"
 
 import Layout from "../components/Layout"
+import LinkedInStream from "../components/LinkedInStream"
 import { getPost, getPosts } from "../lib/api"
 
 interface PostProps extends InferGetStaticPropsType<typeof getStaticProps> {
@@ -11,6 +12,7 @@ export default function Post({ post }: PostProps) {
   return (
     <Layout>
       <NextSeo openGraph={{ title: `Nuts - ${post.meta["title"]}` }} />
+      {post.name === "nieuws" && <LinkedInStream />}
 
       <div className="px-4">
         <article


### PR DESCRIPTION
## Base idea
- show "Nuts Foundation" LinkedIn stream on news page on our website to show more Nuts activity to visitors

## Summary
- this was all generated using Codex, so don't blame me ;-)
- add a new `LinkedInStream` component that loads the LinkedIn company feed script
- show this component on the `nieuws` page so the feed remains visible while scrolling

## Testing
- `npm run lint` *(fails: `next` not found)*